### PR TITLE
FEDORA6-120: Introduce a "usingDocuteamModel" in fcrepo-indexing-triplestore

### DIFF
--- a/docuteam-fcrepo-camel-ext/pom.xml
+++ b/docuteam-fcrepo-camel-ext/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.fcrepo.camel</groupId>
+        <artifactId>fcrepo-camel-toolbox</artifactId>
+        <version>6.2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>docuteam-fcrepo-camel-ext</artifactId>
+
+    <name>docuteam extension of the Fcrepo Camel Component</name>
+    <description>This extension introduce custom behaviour tied to the docuteam model. The goal is to support hash URI
+        metadata subjects</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.fcrepo.camel</groupId>
+            <artifactId>fcrepo-camel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>activemq-client</artifactId>
+            <version>5.16.7</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/docuteam-fcrepo-camel-ext/pom.xml
+++ b/docuteam-fcrepo-camel-ext/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>docuteam-fcrepo-camel-ext</artifactId>
 
     <name>docuteam extension of the Fcrepo Camel Component</name>
-    <description>This extension introduce custom behaviour tied to the docuteam model. The goal is to support hash URI
+    <description>This extension introduces custom behaviour tied to the docuteam model. The goal is to support hash URI
         metadata subjects</description>
     <dependencies>
         <dependency>

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamProcessorUtils.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamProcessorUtils.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
  * This class provide a deleteWhere util method that is tied to the
  * docuteam datamodel compare to the standard one provided in ProcessorUtils
  *
- * @author Vincent Decorges
+ * @author Basil Marti
  */
 public class DocuteamProcessorUtils {
 

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamProcessorUtils.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamProcessorUtils.java
@@ -12,7 +12,7 @@ import org.slf4j.Logger;
 
 /**
  * This class provide a deleteWhere util method that is tied to the
- * docuteam datamodel compare to the standard one provided in ProcessorUtils
+ * docuteam datamodel compared to the standard one provided in ProcessorUtils
  *
  * @author Basil Marti
  */

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamProcessorUtils.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamProcessorUtils.java
@@ -1,0 +1,181 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package ch.docuteam.fcrepo.camel.processor;
+
+import static org.apache.jena.util.URIref.encode;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.slf4j.Logger;
+
+/**
+ * This class provide a deleteWhere util method that is tied to the
+ * docuteam datamodel compare to the standard one provided in ProcessorUtils
+ *
+ * @author Vincent Decorges
+ */
+public class DocuteamProcessorUtils {
+
+    private static final Logger LOGGER  = getLogger(DocuteamProcessorUtils.class);
+
+    private DocuteamProcessorUtils() {
+
+    }
+
+    /**
+     * Create a DELETE WHERE { ... } statement from the provided subject
+     * This is a custom implementation tied to the docuteam model.
+     *
+     * @param subject the subject of the triples to delete.
+     * @param namedGraph an optional named graph
+     * @return the delete statement
+     */
+    public static String deleteWhere(final String subject, final String namedGraph) {
+        final StringBuilder stmt = new StringBuilder(
+                "PREFIX rico: <https://www.ica.org/standards/RiC/ontology#>\nPREFIX premis: <http://www.loc.gov/premis/rdf/v3/>\nPREFIX schema: <http://schema.org/>\nDELETE { ?s ?p ?o } WHERE { ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("GRAPH ");
+            stmt.append("<").append(encode(namedGraph)).append(">");
+            stmt.append(" { ");
+        }
+
+        stmt.append(
+                "?s rico:isOrWasIdentifierOf/rico:thingIsTargetOfRuleRelation/" +
+                        "rico:ruleRelationHasSource/rico:regulatesOrRegulated ");
+        stmt.append("<").append(encode(subject)).append("> . ");
+        stmt.append("?s ?p ?o . ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("} ");
+        }
+
+        stmt.append("}");
+
+        stmt.append(";\n");
+
+        stmt.append("DELETE { ?s ?p ?o } WHERE { ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("GRAPH ");
+            stmt.append("<").append(encode(namedGraph)).append(">");
+            stmt.append(" { ");
+        }
+
+        stmt.append(
+                "?s (rico:thingIsTargetOfEventRelation|rico:thingIsTargetOfRuleRelation)/" +
+                        "(rico:ruleRelationHasSource|rico:eventRelationHasSource)" +
+                        "/(rico:regulatesOrRegulated|rico:isEventAssociatedWith) ");
+        stmt.append("<").append(encode(subject)).append("> . ");
+        stmt.append("?s ?p ?o . ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("} ");
+        }
+
+        stmt.append("}");
+
+        stmt.append(";\n");
+
+        stmt.append("DELETE { ?s ?p ?o } WHERE { ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("GRAPH ");
+            stmt.append("<").append(encode(namedGraph)).append(">");
+            stmt.append(" { ");
+        }
+
+        stmt.append(
+                "?s (rico:isOrWasIdentifierOf|rico:ruleRelationHasSource|" +
+                        "rico:appellationIsSourceOfAppellationRelation|" +
+                        "rico:placeIsSourceOfPlaceRelation|rico:agentIsTargetOfAgentOriginationRelation|" +
+                        "rico:isDateAssociatedWith|rico:isBeginningDateOf|rico:isEndDateOf|" +
+                        "rico:isOrWasAppellationOf|" +
+                        "rico:regulatesOrRegulated|rico:isOrWasSubeventOf|rico:eventRelationHasSource|" +
+                        "rico:ruleIsSourceOfRuleRelation|rico:eventIsSourceOfEventRelation)/" +
+                        "(rico:regulatesOrRegulated|rico:appellationRelationHasTarget|rico:placeRelationHasTarget|" +
+                        "rico:agentOriginationRelationHasSource|rico:isEventAssociatedWith|" +
+                        "rico:ruleRelationHasTarget|" +
+                        "rico:eventRelationHasTarget) ");
+        stmt.append("<").append(encode(subject)).append("> . ");
+        stmt.append("?s ?p ?o . ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("} ");
+        }
+
+        stmt.append("}");
+
+        stmt.append(";\n");
+
+        stmt.append("DELETE { ?s ?p ?o } WHERE { ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("GRAPH ");
+            stmt.append("<").append(encode(namedGraph)).append(">");
+            stmt.append(" { ");
+        }
+
+        stmt.append(
+                "?s (rico:isOrWasTitleOf|rico:isOrWasIdentifierOf|rico:regulatesOrRegulated|" +
+                        "rico:isDocumentaryFormTypeOf|" +
+                        "rico:isOrWasAppellationOf|rico:isExtentOf|rico:isCarrierTypeOf|rico:isContentTypeOf|" +
+                        "rico:isBeginningDateOf|rico:isEndDateOf|rico:isDateAssociatedWith|rico:isLastUpdateDateOf|" +
+                        "rico:isRuleAssociatedWith|rico:isOrWasLanguageOf|rico:appellationRelationHasTarget|" +
+                        "rico:placeRelationHasTarget|rico:agentOriginationRelationHasSource|" +
+                        "rico:isEventAssociatedWith|" +
+                        "rico:ruleRelationHasTarget|rico:eventRelationHasTarget|schema:position) ");
+        stmt.append("<").append(encode(subject)).append("> . ");
+        stmt.append("?s ?p ?o . ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("} ");
+        }
+
+        stmt.append("}");
+
+        stmt.append(";\n");
+
+        stmt.append("DELETE { ?s ?p ?o } WHERE { ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("GRAPH ");
+            stmt.append("<").append(encode(namedGraph)).append(">");
+            stmt.append(" { ");
+        }
+
+        stmt.append("<").append(encode(subject)).append("> ");
+        stmt.append("premis:fixity ?s . ");
+        stmt.append("?s ?p ?o . ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("} ");
+        }
+
+        stmt.append("}");
+
+        stmt.append(";\n");
+
+        stmt.append("DELETE WHERE { ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("GRAPH ");
+            stmt.append("<").append(encode(namedGraph)).append(">");
+            stmt.append(" { ");
+        }
+
+        stmt.append("<").append(encode(subject)).append("> ");
+        stmt.append("?p ?o ");
+
+        if (!namedGraph.isEmpty()) {
+            stmt.append("} ");
+        }
+
+        stmt.append("}");
+
+        return stmt.toString();
+    }
+
+}

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlDeleteProcessor.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlDeleteProcessor.java
@@ -22,7 +22,7 @@ import org.apache.camel.Processor;
 /**
  * Represents a message processor that deletes objects from an
  * external triplestore.
- * This implementation used the docuteam model and was derived from the
+ * This implementation uses the docuteam model and was derived from the
  * standard implementation in fcrepo-camel.
  *
  * @author Vincent Decorges

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlDeleteProcessor.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlDeleteProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package ch.docuteam.fcrepo.camel.processor;
+
+import static ch.docuteam.fcrepo.camel.processor.DocuteamProcessorUtils.deleteWhere;
+
+import static java.net.URLEncoder.encode;
+import static org.apache.camel.Exchange.CONTENT_TYPE;
+import static org.apache.camel.Exchange.HTTP_METHOD;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_NAMED_GRAPH;
+import static org.fcrepo.camel.processor.ProcessorUtils.getSubjectUri;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+
+/**
+ * Represents a message processor that deletes objects from an
+ * external triplestore.
+ * This implementation used the docuteam model and was derived from the
+ * standard implementation in fcrepo-camel.
+ *
+ * @author Vincent Decorges
+ */
+public class DocuteamSparqlDeleteProcessor implements Processor {
+
+    @Override
+    public void process(final Exchange exchange) throws Exception {
+        final Message in = exchange.getIn();
+        final String namedGraph = in.getHeader(FCREPO_NAMED_GRAPH, "", String.class);
+        final String subject = getSubjectUri(exchange);
+
+        in.setBody("update=" + encode(deleteWhere(subject, namedGraph), StandardCharsets.UTF_8));
+        in.setHeader(HTTP_METHOD, "POST");
+        in.setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=utf-8");
+    }
+}

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlUpdateProcessor.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlUpdateProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package ch.docuteam.fcrepo.camel.processor;
+
+import static ch.docuteam.fcrepo.camel.processor.DocuteamProcessorUtils.deleteWhere;
+
+import static java.net.URLEncoder.encode;
+
+import static org.apache.camel.Exchange.CONTENT_TYPE;
+import static org.apache.camel.Exchange.HTTP_METHOD;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_NAMED_GRAPH;
+
+import static org.apache.http.entity.ContentType.parse;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.riot.RDFDataMgr.read;
+import static org.apache.jena.riot.RDFLanguages.contentTypeToLang;
+import static org.fcrepo.camel.processor.ProcessorUtils.getSubjectUri;
+import static org.fcrepo.camel.processor.ProcessorUtils.insertData;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.jena.rdf.model.Model;
+
+/**
+ * Represents a processor for creating the sparql-update message to
+ * be passed to an external triplestore.
+ * This implementation used the docuteam model and was derived from the
+ * standard implementation in fcrepo-camel.
+ *
+ * @author Vincent Decorges
+ */
+public class DocuteamSparqlUpdateProcessor implements Processor {
+
+    @Override
+    public void process(final Exchange exchange) throws Exception {
+        final Message in = exchange.getIn();
+
+        final ByteArrayOutputStream serializedGraph = new ByteArrayOutputStream();
+        final String namedGraph = in.getHeader(FCREPO_NAMED_GRAPH, "", String.class);
+        final Model model = createDefaultModel();
+        final String subject = getSubjectUri(exchange);
+
+        read(model, in.getBody(InputStream.class),
+                contentTypeToLang(parse(in.getHeader(CONTENT_TYPE, String.class)).getMimeType()));
+
+        model.write(serializedGraph, "N-TRIPLE");
+
+        in.setBody("update=" + encode(deleteWhere(subject, namedGraph) + ";\n" +
+                insertData(serializedGraph.toString("UTF-8"), namedGraph), "UTF-8"));
+
+        in.setHeader(HTTP_METHOD, "POST");
+        in.setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=utf-8");
+    }
+}

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlUpdateProcessor.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/DocuteamSparqlUpdateProcessor.java
@@ -22,6 +22,7 @@ import static org.fcrepo.camel.processor.ProcessorUtils.insertData;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -53,7 +54,8 @@ public class DocuteamSparqlUpdateProcessor implements Processor {
         model.write(serializedGraph, "N-TRIPLE");
 
         in.setBody("update=" + encode(deleteWhere(subject, namedGraph) + ";\n" +
-                insertData(serializedGraph.toString("UTF-8"), namedGraph), "UTF-8"));
+                insertData(serializedGraph.toString(StandardCharsets.UTF_8),
+                        namedGraph), StandardCharsets.UTF_8));
 
         in.setHeader(HTTP_METHOD, "POST");
         in.setHeader(CONTENT_TYPE, "application/x-www-form-urlencoded; charset=utf-8");

--- a/fcrepo-indexing-triplestore/pom.xml
+++ b/fcrepo-indexing-triplestore/pom.xml
@@ -42,6 +42,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>docuteam-fcrepo-camel-ext</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-spring</artifactId>
     </dependency>
@@ -128,6 +133,12 @@
       <groupId>org.fcrepo.client</groupId>
       <artifactId>fcrepo-java-client</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>docuteam-fcrepo-camel-ext</artifactId>
+      <version>6.2.0-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 

--- a/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/FcrepoTripleStoreIndexingConfig.java
+++ b/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/FcrepoTripleStoreIndexingConfig.java
@@ -31,6 +31,9 @@ public class FcrepoTripleStoreIndexingConfig extends BasePropsConfig {
         }
     }
 
+    @Value("${triplestore.using.docuteam.model:true}")
+    private boolean usingDocuteamModel;
+
     @Value("${triplestore.input.stream:broker:topic:fedora}")
     private String inputStream;
 
@@ -60,6 +63,10 @@ public class FcrepoTripleStoreIndexingConfig extends BasePropsConfig {
 
     @Value("${triplestore.authPassword:}")
     private String triplestoreAuthPassword;
+
+    public boolean isUsingDocuteamModel() {
+        return usingDocuteamModel;
+    }
 
     public String getInputStream() {
         return inputStream;

--- a/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
+++ b/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
@@ -5,6 +5,8 @@
  */
 package org.fcrepo.camel.indexing.triplestore;
 
+import ch.docuteam.fcrepo.camel.processor.DocuteamSparqlDeleteProcessor;
+import ch.docuteam.fcrepo.camel.processor.DocuteamSparqlUpdateProcessor;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.language.xpath.XPathBuilder;
@@ -111,7 +113,7 @@ public class TriplestoreRouter extends RouteBuilder {
          */
         from("direct:delete.triplestore")
             .routeId("FcrepoTriplestoreDeleter")
-            .process(new SparqlDeleteProcessor())
+            .process(config.isUsingDocuteamModel() ? new DocuteamSparqlDeleteProcessor() : new SparqlDeleteProcessor())
             .log(LoggingLevel.INFO, LOGGER,
                 "Deleting Triplestore Object ${headers[CamelFcrepoUri]}")
             .process(new AddBasicAuthProcessor(this.config.getTriplestoreAuthUsername(),
@@ -127,7 +129,7 @@ public class TriplestoreRouter extends RouteBuilder {
             .simple(config.getNamedGraph())
             .to("fcrepo:" + config.getFcrepoBaseUrl() + "?accept=application/n-triples" +
                 "&preferOmit=" + config.getPreferOmit() + "&preferInclude=" + config.getPreferInclude())
-            .process(new SparqlUpdateProcessor())
+            .process(config.isUsingDocuteamModel() ? new DocuteamSparqlUpdateProcessor() : new SparqlUpdateProcessor())
             .log(LoggingLevel.INFO, LOGGER,
                 "Indexing Triplestore Object ${headers[CamelFcrepoUri]}")
             .process(new AddBasicAuthProcessor(this.config.getTriplestoreAuthUsername(),

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/DocuteamRouteTest.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/DocuteamRouteTest.java
@@ -1,0 +1,128 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package org.fcrepo.camel.indexing.triplestore;
+
+import static java.net.URLEncoder.encode;
+import static java.util.Arrays.asList;
+import static org.apache.camel.util.ObjectHelper.loadResourceAsStream;
+
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWith;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.model.ModelCamelContext;
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+
+/**
+ * Test the custom route workflow.
+ *
+ * @author Vincent Decorges
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {RouteTest.ContextConfig.class}, loader = AnnotationConfigContextLoader.class)
+public class DocuteamRouteTest {
+
+    private static final String REPOSITORY = "http://fedora.info/definitions/v4/repository#";
+
+    @Produce("direct:start")
+    protected ProducerTemplate template;
+
+    @Autowired
+    private CamelContext camelContext;
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("triplestore.indexing.enabled", "true");
+        System.setProperty("triplestore.indexing.predicate", "true");
+        System.setProperty("triplestore.input.stream", "seda:foo");
+        System.setProperty("triplestore.reindex.stream", "seda:reindex");
+        System.setProperty("triplestore.using.docuteam.model", "true");
+    }
+
+    @DirtiesContext
+    @Test
+    public void testUpdateRouter() throws Exception {
+
+        final String document = IOUtils.toString(loadResourceAsStream("container.nt"), "UTF-8").trim();
+        final String responsePrefix =
+                "PREFIX rico: <https://www.ica.org/standards/RiC/ontology#>\nPREFIX premis: " +
+                        "<http://www.loc.gov/premis/rdf/v3/>\n" +
+                        "PREFIX schema: <http://schema.org/>\n" +
+                        "DELETE { ?s ?p ?o }" +
+                        " WHERE { ?s rico:isOrWasIdentifierOf/rico:thingIsTargetOfRuleRelation/" +
+                        "rico:ruleRelationHasSource/rico:regulatesOrRegulated <" +
+                        RouteTest.baseURL + RouteTest.fileID +
+                        "> . ?s ?p ?o . };\nDELETE { ?s ?p ?o } WHERE { ?s (rico:thingIsTargetOfEventRelation|" +
+                        "rico:thingIsTargetOfRuleRelation)/(rico:ruleRelationHasSource|" +
+                        "rico:eventRelationHasSource)/(rico:regulatesOrRegulated|" + "rico:isEventAssociatedWith) <" +
+                        RouteTest.baseURL + RouteTest.fileID +
+                        "> . ?s ?p ?o . };\nDELETE { ?s ?p ?o } WHERE { ?s (rico:isOrWasIdentifierOf|" +
+                        "rico:ruleRelationHasSource|rico:appellationIsSourceOfAppellationRelation|" +
+                        "rico:placeIsSourceOfPlaceRelation|rico:agentIsTargetOfAgentOriginationRelation|" +
+                        "rico:isDateAssociatedWith|rico:isBeginningDateOf|rico:isEndDateOf|rico:isOrWasAppellationOf|" +
+                        "rico:regulatesOrRegulated|rico:isOrWasSubeventOf|rico:eventRelationHasSource|" +
+                        "rico:ruleIsSourceOfRuleRelation|rico:eventIsSourceOfEventRelation)/" +
+                        "(rico:regulatesOrRegulated|rico:appellationRelationHasTarget|rico:placeRelationHasTarget|" +
+                        "rico:agentOriginationRelationHasSource|rico:isEventAssociatedWith|" +
+                        "rico:ruleRelationHasTarget|rico:eventRelationHasTarget) <" +
+                        RouteTest.baseURL + RouteTest.fileID +
+                        "> . ?s ?p ?o . };\nDELETE { ?s ?p ?o } WHERE { ?s " +
+                        "(rico:isOrWasTitleOf|rico:isOrWasIdentifierOf|" +
+                        "rico:regulatesOrRegulated|rico:isDocumentaryFormTypeOf|rico:isOrWasAppellationOf|" +
+                        "rico:isExtentOf|rico:isCarrierTypeOf|rico:isContentTypeOf|rico:isBeginningDateOf|" +
+                        "rico:isEndDateOf|rico:isDateAssociatedWith|rico:isLastUpdateDateOf|" +
+                        "rico:isRuleAssociatedWith|" +
+                        "rico:isOrWasLanguageOf|rico:appellationRelationHasTarget|rico:placeRelationHasTarget|" +
+                        "rico:agentOriginationRelationHasSource|rico:isEventAssociatedWith|" +
+                        "rico:ruleRelationHasTarget|rico:eventRelationHasTarget|schema:position) <" +
+                        RouteTest.baseURL + RouteTest.fileID + "> . ?s ?p ?o . };\nDELETE { ?s ?p ?o } WHERE { <" +
+                        RouteTest.baseURL + RouteTest.fileID +
+                        "> premis:fixity ?s . ?s ?p ?o . };\nDELETE WHERE { <" + RouteTest.baseURL +
+                        RouteTest.fileID + "> ?p ?o };\n" +
+                        "INSERT DATA { ";
+
+        final var context = camelContext.adapt(ModelCamelContext.class);
+
+        AdviceWith.adviceWith(context, "FcrepoTriplestoreUpdater", a -> {
+            a.mockEndpointsAndSkip("fcrepo*");
+            a.mockEndpointsAndSkip("http*");
+        });
+
+        final MockEndpoint endpoint = MockEndpoint.resolve(camelContext, "mock:http:localhost:8080/fuseki/test/update");
+
+        endpoint.expectedMessageCount(1);
+        endpoint.expectedHeaderReceived(Exchange.HTTP_METHOD, "POST");
+        endpoint.expectedHeaderReceived(Exchange.CONTENT_TYPE, "application/x-www-form-urlencoded; charset=utf-8");
+        endpoint.allMessages().body().startsWith("update=" + encode(responsePrefix, "UTF-8"));
+        endpoint.allMessages().body().endsWith(encode("\n}", "UTF-8"));
+        for (final String s : document.split("\n")) {
+            endpoint.expectedBodyReceived().body().contains(encode(s, "UTF-8"));
+        }
+
+        final Map<String, Object> headers = RouteTest.createEvent(RouteTest.baseURL + RouteTest.fileID,
+                asList(RouteTest.AS_NS + "Create"),
+                asList(REPOSITORY + "Container"));
+        headers.put(Exchange.CONTENT_TYPE, "application/rdf+xml");
+
+        template.sendBodyAndHeaders("direct:update.triplestore",
+                IOUtils.toString(loadResourceAsStream("container.rdf"), "UTF-8"),
+                headers);
+
+        endpoint.assertIsSatisfied();
+    }
+}

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/RouteTest.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/RouteTest.java
@@ -65,15 +65,15 @@ public class RouteTest {
     private CamelContext camelContext;
 
 
-    private static final String baseURL = "http://localhost/rest";
-    private static final String fileID = "/file1";
-    private static final long timestamp = 1428360320168L;
-    private static final String eventDate = "2015-04-06T22:45:20Z";
-    private static final String userID = "bypassAdmin";
-    private static final String userAgent = "curl/7.37.1";
-    private static final String auditContainer = "/audit";
-    private static final String AS_NS = "https://www.w3.org/ns/activitystreams#";
-    private static final String INDEXABLE = "http://fedora.info/definitions/v4/indexing#Indexable";
+    static final String baseURL = "http://localhost/rest";
+    static final String fileID = "/file1";
+    static final long timestamp = 1428360320168L;
+    static final String eventDate = "2015-04-06T22:45:20Z";
+    static final String userID = "bypassAdmin";
+    static final String userAgent = "curl/7.37.1";
+    static final String auditContainer = "/audit";
+    static final String AS_NS = "https://www.w3.org/ns/activitystreams#";
+    static final String INDEXABLE = "http://fedora.info/definitions/v4/indexing#Indexable";
 
 
     @BeforeClass
@@ -83,10 +83,11 @@ public class RouteTest {
         System.setProperty("triplestore.filter.containers", auditContainer);
         System.setProperty("triplestore.input.stream", "seda:foo");
         System.setProperty("triplestore.reindex.stream", "seda:reindex");
+        System.setProperty("triplestore.using.docuteam.model", "false");
 
     }
 
-    private static Map<String, Object> createEvent(final String identifier, final List<String> eventTypes,
+    static Map<String, Object> createEvent(final String identifier, final List<String> eventTypes,
                                                    final List<String> resourceTypes) {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(FCREPO_URI, identifier);
@@ -345,7 +346,7 @@ public class RouteTest {
         endpoint.assertIsSatisfied();
     }
 
-    private static Map<String, Object> createEvent(final String identifier, final List<String> eventTypes) {
+    static Map<String, Object> createEvent(final String identifier, final List<String> eventTypes) {
         return createEvent(identifier, eventTypes, emptyList());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <module>fcrepo-camel-common</module>
     <module>fcrepo-fixity</module>
     <module>fcrepo-audit-triplestore</module>
+    <module>docuteam-fcrepo-camel-ext</module>
   </modules>
 
   <repositories>


### PR DESCRIPTION

- The new module dcouteam-fcrepo-camel-ext contains the change to the Sparql requestes for delete and update to use the docuteam model.
- Introduce the new properties triplestore.using.docuteam.model to modify the behaviour of the triplestore indexer in case of update. By default it is set to true. Setting this properties to false revert to the standard behaviour.
- Add a DocuteamRouterTest test for the custom behaviour.

**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3932

# Additional Notes:
We some additional integration test for the custom behavior.


