### PR TITLE
Fedora6 140 introduce batch in route

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,19 +154,22 @@ This application listens to Fedora's event stream and
 indexes objects into an external triplestore.
 
 #### Properties
-| Name      | Description| Default Value |
-| :---      | :---| :----   |
-| triplestore.indexing.enabled | Enables the triplestore indexing service. Disabled by default | false | 
-| triplestore.baseUrl | Base URL for the triplestore | http://localhost:8080/fuseki/test/update | 
-| triplestore.authUsername | Username for basic authentication against triplestore | 
-| triplestore.authPassword | Password for basic authentication against triplestore | 
-| triplestore.input.stream |   The JMS topic or queue serving as the message source    | broker:topic:fedora | 
-| triplestore.reindex.stream |   The JMS topic or queue serving as the reindex message source    | broker:queue:triplestore.reindex | 
-| triplestore.indexing.predicate | When true, check that resource is of type http://fedora.info/definitions/v4/indexing#Indexable; otherwise do not index it.   | false |
-| triplestore.filter.containers |   A comma-separate list of containers that should be ignored by the indexer  | http://localhost:8080/fcrepo/rest/audit | 
-| triplestore.namedGraph |  A named graph to be used when indexing rdf  | null |  
-| triplestore.prefer.include |  A list of [valid prefer values](https://fedora.info/2021/05/01/spec/#additional-prefer-values) defining predicates to be included  | null |  
-| triplestore.prefer.omit | A list of [valid prefer values](https://fedora.info/2021/05/01/spec/#additional-prefer-values) defining predicates to be omitted. | http://www.w3.org/ns/ldp#PreferContainment |  
+| Name                                  | Description                                                                                                                       | Default Value                              |
+|:--------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------|:-------------------------------------------|
+| triplestore.indexing.enabled          | Enables the triplestore indexing service. Disabled by default                                                                     | false                                      | 
+| triplestore.baseUrl                   | Base URL for the triplestore                                                                                                      | http://localhost:8080/fuseki/test/update   | 
+| triplestore.authUsername              | Username for basic authentication against triplestore                                                                             | 
+| triplestore.authPassword              | Password for basic authentication against triplestore                                                                             | 
+| triplestore.input.stream              | The JMS topic or queue serving as the message source                                                                              | broker:topic:fedora                        | 
+| triplestore.reindex.stream            | The JMS topic or queue serving as the reindex message source                                                                      | broker:queue:triplestore.reindex           | 
+| triplestore.indexing.predicate        | When true, check that resource is of type http://fedora.info/definitions/v4/indexing#Indexable; otherwise do not index it.        | false                                      |
+| triplestore.filter.containers         | A comma-separate list of containers that should be ignored by the indexer                                                         | http://localhost:8080/fcrepo/rest/audit    | 
+| triplestore.namedGraph                | A named graph to be used when indexing rdf                                                                                        | null                                       |  
+| triplestore.prefer.include            | A list of [valid prefer values](https://fedora.info/2021/05/01/spec/#additional-prefer-values) defining predicates to be included | null                                       |  
+| triplestore.prefer.omit               | A list of [valid prefer values](https://fedora.info/2021/05/01/spec/#additional-prefer-values) defining predicates to be omitted. | http://www.w3.org/ns/ldp#PreferContainment |
+| triplestore.using.docuteam.model      | When true, it follows the docuteam data model and delete separate resources as well                                               | true                                       |
+| triplestore.aggregator.completion.size| Specify the number of record ressources to aggregate before calling the Fuseki update endpoint                                    | 100                                        |
+| triplestore.aggregator.completion.timeout| Specify the number of milliseconds to wait before calling the Fuseki update endpoint if completion.size has not been reached      | 5000                                       |
 
 ### Reindexing Service
 

--- a/docuteam-fcrepo-camel-ext/pom.xml
+++ b/docuteam-fcrepo-camel-ext/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.fcrepo.camel</groupId>
+        <groupId>ch.docuteam</groupId>
         <artifactId>fcrepo-camel-toolbox</artifactId>
-        <version>6.2.0-SNAPSHOT</version>
+        <version>${fcrepo-camel-toolbox.version}</version>
     </parent>
 
     <artifactId>docuteam-fcrepo-camel-ext</artifactId>

--- a/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/SparqlAggregationStrategy.java
+++ b/docuteam-fcrepo-camel-ext/src/main/java/ch/docuteam/fcrepo/camel/processor/SparqlAggregationStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree.
+ */
+package ch.docuteam.fcrepo.camel.processor;
+
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.Exchange;
+
+/**
+ * Aggregate Sparql queries
+ *
+ * @author Vincent Decorges
+ */
+public class SparqlAggregationStrategy implements AggregationStrategy {
+
+    @Override
+    public Exchange aggregate(final Exchange oldExchange, final Exchange newExchange) {
+        if (oldExchange == null) {
+            return newExchange; // First message in batch
+        }
+
+        final String oldBody = oldExchange.getIn().getBody(String.class);
+        final String newBody = newExchange.getIn().getBody(String.class).replace("update=", "");
+
+        final String aggregatedQuery = oldBody + ";\n" + newBody;
+
+        oldExchange.getIn().setBody(aggregatedQuery);
+        return oldExchange;
+    }
+
+}

--- a/fcrepo-audit-triplestore/pom.xml
+++ b/fcrepo-audit-triplestore/pom.xml
@@ -4,9 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.fcrepo.camel</groupId>
+    <groupId>ch.docuteam</groupId>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <version>6.2.0-SNAPSHOT</version>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-audit-triplestore</artifactId>

--- a/fcrepo-camel-common/pom.xml
+++ b/fcrepo-camel-common/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/fcrepo-camel-toolbox-app/pom.xml
+++ b/fcrepo-camel-toolbox-app/pom.xml
@@ -2,8 +2,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/fcrepo-fixity/pom.xml
+++ b/fcrepo-fixity/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-fixity</artifactId>

--- a/fcrepo-http-forwarding/pom.xml
+++ b/fcrepo-http-forwarding/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-http-forwarding</artifactId>

--- a/fcrepo-indexing-solr/pom.xml
+++ b/fcrepo-indexing-solr/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-indexing-solr</artifactId>

--- a/fcrepo-indexing-triplestore/pom.xml
+++ b/fcrepo-indexing-triplestore/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-indexing-triplestore</artifactId>
@@ -62,7 +62,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.fcrepo.camel</groupId>
+      <groupId>${project.parent.groupId}</groupId>
       <artifactId>fcrepo-camel-common</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
@@ -98,7 +98,7 @@
     </dependency>
 
     <dependency>
-        <groupId>org.fcrepo.camel</groupId>
+        <groupId>${project.parent.groupId}</groupId>
         <artifactId>fcrepo-service-camel</artifactId>
         <version>${project.parent.version}</version>
         <scope>test</scope>

--- a/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/FcrepoTripleStoreIndexingConfig.java
+++ b/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/FcrepoTripleStoreIndexingConfig.java
@@ -64,6 +64,13 @@ public class FcrepoTripleStoreIndexingConfig extends BasePropsConfig {
     @Value("${triplestore.authPassword:}")
     private String triplestoreAuthPassword;
 
+    @Value("${triplestore.aggregator.completion.size:100}")
+    private Integer triplestoreAggregatorCompletionSize;
+
+    // In MS
+    @Value("${triplestore.aggregator.completion.timeout:5000}")
+    private Long triplestoreAggregatorCompletionTimeout;
+
     public boolean isUsingDocuteamModel() {
         return usingDocuteamModel;
     }
@@ -106,6 +113,14 @@ public class FcrepoTripleStoreIndexingConfig extends BasePropsConfig {
 
     public String getTriplestoreAuthPassword() {
         return triplestoreAuthPassword;
+    }
+
+    public Integer getTriplestoreAggregatorCompletionSize() {
+        return triplestoreAggregatorCompletionSize;
+    }
+
+    public Long getTriplestoreAggregatorCompletionTimeout() {
+        return triplestoreAggregatorCompletionTimeout;
     }
 
     @Bean(name = "http")

--- a/fcrepo-reindexing/pom.xml
+++ b/fcrepo-reindexing/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-reindexing</artifactId>

--- a/fcrepo-service-activemq/pom.xml
+++ b/fcrepo-service-activemq/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-service-activemq</artifactId>

--- a/fcrepo-service-camel/pom.xml
+++ b/fcrepo-service-camel/pom.xml
@@ -5,8 +5,8 @@
 
   <parent>
     <artifactId>fcrepo-camel-toolbox</artifactId>
-    <groupId>org.fcrepo.camel</groupId>
-    <version>6.2.0-SNAPSHOT</version>
+    <groupId>ch.docuteam</groupId>
+    <version>${fcrepo-camel-toolbox.version}</version>
   </parent>
 
   <artifactId>fcrepo-service-camel</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.fcrepo.camel</groupId>
   <artifactId>fcrepo-camel-toolbox</artifactId>
   <packaging>pom</packaging>
-  <version>6.2.0-SNAPSHOT</version>
+  <version>6.2.0-docuteam-SNAPSHOT</version>
 
   <name>Fedora Camel Workflows</name>
   <description>A collection of camel-based event-driven workflows</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,10 @@
     <version>6.1.0</version>
   </parent>
 
-  <groupId>org.fcrepo.camel</groupId>
+  <groupId>ch.docuteam</groupId>
   <artifactId>fcrepo-camel-toolbox</artifactId>
   <packaging>pom</packaging>
-  <version>6.2.0-docuteam-SNAPSHOT</version>
+  <version>${fcrepo-camel-toolbox.version}</version>
 
   <name>Fedora Camel Workflows</name>
   <description>A collection of camel-based event-driven workflows</description>
@@ -29,6 +29,8 @@
     <project_name>fcrepo-camel-toolbox</project_name>
     <project_organization>fcrepo-exts</project_organization>
     <project.copyrightYear>2016</project.copyrightYear>
+
+    <fcrepo-camel-toolbox.version>1.0.0</fcrepo-camel-toolbox.version>
 
     <!-- dependencies -->
     <activemq.version>5.16.7</activemq.version>


### PR DESCRIPTION
**Introduce aggregate on the Triplestore index route**
* * *

**JIRA Ticket**: [(link)](https://docuteam.atlassian.net/browse/FEDORA6-140)

# What does this Pull Request do?
It aggregate SPARQL insert queries before calling the update endpoint of the triplestore. The parameters triplestore.aggregator.completion.size and triplestore.aggregator.completion.timeout allow to configure the number of SPARQL that will be aggregated. By default it is set to batch of 100 queries or the number reach before the define timeout (5000 ms). 

# What's new?
* Introduce parameter triplestore.aggregator.completion.size
* Introduce parameter triplestore.aggregator.completion.timeout 

# How should this be tested?

* This PR introduce an optimization on top of triplestore indexing. The whole tests suit for indexing in triplestore can be used to test the optimizations.
* There is a new log message to see the number of  Aggregated queries in debug level: "Aggregated messages count: ..."
* The resulting SPARQL requests sent to Fuseki is available in trace level: "SPARQL Batch Query: ..."


# Additional Notes:
Performance test where done on RED system with the following results with a test data set of 5'044'791 triples

## Without aggregation:
index size 75 GB after 14 hours of processing (25% of data left to proceed).
Number of call to Fuseki update 76'762

## With aggregation (default config):
index size 9.13 GB. Processing time 1h01.
Number of call to Fuseki update 1'025

